### PR TITLE
Hide #broq-filter=.

### DIFF
--- a/src/ts/index.ts
+++ b/src/ts/index.ts
@@ -66,9 +66,13 @@ function checkFilter() {
   filter = $('#filter')
     .val()
     .toString();
-  port.postMessage({ json: input, filter: filter });
-  filter = encodeURIComponent(filter);
-  window.location.hash = 'broq-filter=' + filter;
+  if(filter != '.') {
+    port.postMessage({ json: input, filter: filter });
+    filter = encodeURIComponent(filter);
+    window.location.hash = 'broq-filter=' + filter;
+  } else if(window.location.hash.includes('#broq-filter=')) {
+    history.pushState("", document.title, window.location.pathname + window.location.search);
+  }
 }
 
 document.addEventListener('DOMContentLoaded', onLoad, false);


### PR DESCRIPTION
Hide the url fragment #broq-filter= if only the default filter is applied.
- add check if only the default filter is set
- remove url fragment if only the default filter is set

closes #8 