### PR TITLE
Add live url query option

### DIFF
--- a/src/css/skeleton.css
+++ b/src/css/skeleton.css
@@ -619,16 +619,17 @@ button:active {
 #filterTitleDiv {
   display: inline-block;
   width: 100%;
+  margin-bottom: 6px;
 }
 
-#curlButton {
-  position: relative;
-  margin: 0 16 6;
+#filterTitleDiv .button-group {
+  margin: 0 16px;
 }
 
 #linkToInfo {
   position: relative;
-  margin: 0 7px;
+  margin-left: 10px;
+  margin-right: 20px;
 }
 
 #questionmark {

--- a/src/pages/options.html
+++ b/src/pages/options.html
@@ -156,6 +156,14 @@
                         </span> drag enabled
                     </label>
                 </div>
+                <div class="checkbox">
+                    <label>
+                        <input id="liveUrlQuery" type="checkbox">
+                        <span class="checkbox-material">
+                            <span class="check"></span>
+                        </span> live url query
+                    </label>
+                </div>
 
                 <div class="button-container">
                     <button id="save-btn" class="button" type="button">

--- a/src/ts/options.ts
+++ b/src/ts/options.ts
@@ -44,7 +44,7 @@ const themes = {
     Xcode: aceThemePath + 'xcode'
 };
 
-const defaultOptions = {
+const defaultEditorOptions = {
     highlightActiveLine: true,
     highlightSelectedWord: true,
     readOnly: true,
@@ -59,6 +59,12 @@ const defaultOptions = {
     dragEnabled: true
 };
 
+const defaultCustomOptions = {
+    liveUrlQuery: true
+};
+
+export const defaultOptions = Object.assign({}, defaultEditorOptions, defaultCustomOptions);
+
 export function checkStorageOptions() {
     chrome.storage.sync.get(['options'], function (result) {
         if (result.options === undefined) {
@@ -72,6 +78,17 @@ $(function () {
     getOptions();
 });
 
+export function parseOptions (options: string) {
+    return Object.assign({}, defaultOptions, JSON.parse(options))
+}
+
+export function parseEditorOptions (options: string) {
+    const parsedOptions = JSON.parse(options);
+    return Object.keys(defaultEditorOptions).reduce((accum, key) => (
+        Object.assign(accum, { [key]: parsedOptions[key] })
+    ), { ...defaultEditorOptions });
+}
+
 function getOptions() {
     chrome.storage.onChanged.addListener(function (changes) {
         for (let key in changes) {
@@ -82,7 +99,7 @@ function getOptions() {
     });
     chrome.storage.sync.get(['options'], function (result) {
         if (result.options != undefined) {
-            let options = JSON.parse(result.options);
+            const options = parseOptions(result.options);
             $('#theme').val(
                 Object.keys(themes).find(key => themes[key] === options.theme)
             );
@@ -111,7 +128,7 @@ function saveOptions() {
         if (currentOptions === null) {
             currentOptions = defaultOptions;
         } else {
-            currentOptions = JSON.parse(currentOptions);
+            currentOptions = parseOptions(currentOptions);
         }
         let options = JSON.parse(JSON.stringify(currentOptions));
 


### PR DESCRIPTION
* Allow a user to disable the query hash updating as they type a jq filter.
* Add a copy sharable url button which copies a url that includes query in the hash for sharing.

The default for the option is enabled which leaves the extensions behavior as it currently stands.

<img width="718" alt="screen shot 2018-08-05 at 10 24 22 am" src="https://user-images.githubusercontent.com/6855046/43686857-59a62568-989a-11e8-822c-760956d597b1.png">
<img width="1260" alt="screen shot 2018-08-05 at 10 24 39 am" src="https://user-images.githubusercontent.com/6855046/43686858-59b00e3e-989a-11e8-93ca-affa8e06dc62.png">
