### PR TITLE
Add loading bar to top of screen

### DIFF
--- a/src/css/skeleton.css
+++ b/src/css/skeleton.css
@@ -801,3 +801,79 @@ button:active {
 .hidden {
     display: none;
 }
+
+/* Loading bar */
+@-webkit-keyframes animate-width {
+    0% {
+      width: 0;
+    }
+    100% {
+      visibility: visible;
+    }
+}
+@-moz-keyframes animate-width {
+    0% {
+      width: 0;
+    }
+    100% {
+      visibility: visible;
+    }
+}
+@keyframes animate-width {
+    0% {
+      width: 0;
+    }
+    100% {
+      visibility: visible;
+    }
+}
+@-webkit-keyframes animate-height {
+    0% {
+      height: 0;
+    }
+    100% {
+      visibility: visible;
+    }
+}
+@-moz-keyframes animate-height {
+    0% {
+      height: 0;
+    }
+    100% {
+      visibility: visible;
+    }
+}
+@keyframes animate-height {
+    0% {
+      height: 0;
+    }
+    100% {
+      visibility: visible;
+    }
+}
+
+.loading-bar {
+    float: left;
+    width: 0;
+    height: 5px;
+    visibility: hidden;
+    background-color: #448abe;
+    -webkit-box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+    box-shadow: inset 0 -1px 0 rgba(0, 0, 0, 0.15);
+    height: 5px;
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    -webkit-animation: animate-width;
+    -moz-animation: animate-width;
+    animation: animate-width;
+    animation-timing-function: cubic-bezier(0.35, 0.95, 0.67, 0.99);
+    -webkit-animation-timing-function: cubic-bezier(0.35, 0.95, 0.67, 0.99);
+    -moz-animation-timing-function: cubic-bezier(0.35, 0.95, 0.67, 0.99);
+    animation-duration: 0.5s;
+    -webkit-animation-duration: 0.5s;
+    -moz-animation-duration: 0.5s;
+    animation-fill-mode: forwards;
+    -webkit-animation-fill-mode: forwards;
+}
+  

--- a/src/ts/App/index.tsx
+++ b/src/ts/App/index.tsx
@@ -1,8 +1,9 @@
 import { h, Component } from 'preact';
-import FilterHeaderBar from './filterHeaderBar'
-import FilterBar from './filterBar'
-import Errors from './errors'
-import InputOutput from './inputOutput'
+import FilterHeaderBar from './filterHeaderBar';
+import FilterBar from './filterBar';
+import Errors from './errors';
+import InputOutput from './inputOutput';
+import LoadingBar from './loadingBar';
 
 export interface AppProps {
   initialFilter: string;
@@ -18,6 +19,7 @@ interface AppState {
   inputJson: string;
   errors: string;
   options: string;
+  loading: boolean;
 }
 
 export default class App extends Component<AppProps, AppState> {
@@ -29,6 +31,7 @@ export default class App extends Component<AppProps, AppState> {
       errors: props.errors,
       inputJson: props.inputJson,
       options: props.options,
+      loading: false,
     };
   }
 
@@ -39,7 +42,8 @@ export default class App extends Component<AppProps, AppState> {
     this.port.onMessage.addListener(msg => {
       this.setState({
         outputJson: msg.jqResult,
-        errors: msg.error
+        errors: msg.error,
+        loading: false
       });
     });
     this.runJqFilter();
@@ -63,13 +67,15 @@ export default class App extends Component<AppProps, AppState> {
 
   runJqFilter = () => {
     const { inputJson, filter } = this.state;
+    this.setState({loading: true, errors: ""});
     this.port.postMessage({ json: inputJson, filter: filter });
   }
 
   render() {
-    const { inputJson, outputJson, errors, filter, options } = this.state;
+    const { inputJson, outputJson, errors, filter, options, loading } = this.state;
     const { documentUrl } = this.props;
     return <div>
+      {!!this.state.loading && <LoadingBar /> }
       <link
         href={chrome.extension.getURL('/css/skeleton.css')}
         type="text/css"
@@ -80,6 +86,7 @@ export default class App extends Component<AppProps, AppState> {
           <FilterHeaderBar filter={filter} documentUrl={documentUrl} updateFilter={this.updateFilter} />
           <FilterBar filter={filter} updateFilter={this.updateFilter} />
           <Errors errors={errors} />
+
         </div>
       </div>
       <InputOutput

--- a/src/ts/App/loadingBar.tsx
+++ b/src/ts/App/loadingBar.tsx
@@ -1,0 +1,12 @@
+import { h, Component, render } from 'preact';
+
+export default class LoadingBar extends Component {
+
+    render(){
+        return (
+            <div>
+                <span class="loading-bar" style="width: 95%;"></span>
+            </div>
+        )
+    }
+}


### PR DESCRIPTION
This PR fixes https://github.com/zalando-incubator/bro-q/issues/291 by adding an absolutely positioned CSS animated loading bar to the top of the screen whenever a new filter is applied. After the filter has rendered, the loading bar is removed from the screen.