### PR TITLE
Finish fixing the grab bag of various issues

### DIFF
--- a/src/css/skeleton.css
+++ b/src/css/skeleton.css
@@ -657,8 +657,6 @@ button:active {
 
 #errors {
     font-size: 16px;
-    width: 48%;
-    margin-left: 2%;
     margin-top: auto;
     height: 20px;
     display: inline-block;
@@ -667,7 +665,7 @@ button:active {
 
 #filter {
     font-size: 16px;
-    width: 50%;
+    width: 100%;
     margin-top: auto;
 }
 
@@ -707,6 +705,11 @@ button:active {
 
 #logoDiv {
     width: 100px;
+    display: block;
+    position: absolute;
+    top: -20px;
+    right: 10px;
+    height: 100px;
 }
 
 .flex-row {
@@ -735,12 +738,13 @@ button:active {
 #json-editor-input,
 #json-editor-output {
     position: relative;
-    height: 95%;
+    height: 93%;
 }
 
 #outputToolbar {
     height: 5%;
     text-align: right;
+    display: block;
 }
 
 .modal {

--- a/src/ts/App/Components/braceEditor.tsx
+++ b/src/ts/App/Components/braceEditor.tsx
@@ -65,6 +65,7 @@ export default class BraceEditor extends Component<BraceProps, BraceState> {
     editor.setValue(value);
     editor.clearSelection();
     editor.scrollToLine(0, false, true, null);
+    editor.resize(true);
   }
 
   componentDidMount() {
@@ -76,10 +77,10 @@ export default class BraceEditor extends Component<BraceProps, BraceState> {
     editor.getSession().setMode('ace/mode/json');
     editor.setTheme(options.theme || DEFAULT_THEME);
     editor.$blockScrolling = Infinity;
-
+    editor.resize(true);
+    editor.setShowPrintMargin(false);
     console.log(options);
     editor.setOptions({
-      maxLines: Infinity,
       ...options
     });
   }

--- a/src/ts/App/errors.tsx
+++ b/src/ts/App/errors.tsx
@@ -13,6 +13,7 @@ export default class Errors extends Component<ErrorsProps> {
       <div
         id="errors"
         name="errors"
+        class="one-half column"
       >{errors}</div>
     );
   }

--- a/src/ts/App/filterBar.tsx
+++ b/src/ts/App/filterBar.tsx
@@ -65,13 +65,15 @@ export default class FilterBar extends Component<FilterBarProps, FilterBarState>
     const { value } = this.state;
 
     return (
-      <input
-        onKeyUp={this.handleKeyDown}
-        id="filter"
-        name="filter"
-        type="text"
-        value={value}
-      />
+      <div class="one-half column">
+        <input
+          onKeyUp={this.handleKeyDown}
+          id="filter"
+          name="filter"
+          type="text"
+          value={value}
+        />
+      </div>
     );
   }
 }

--- a/src/ts/App/inputOutput.tsx
+++ b/src/ts/App/inputOutput.tsx
@@ -5,22 +5,35 @@ import { Clipboard } from 'ts-clipboard';
 export interface InputOutputProps {
   inputJson: string;
   outputJson: string;
-  options: string;
+  options: object;
+}
+
+export interface InputOutputState {
+  hideUnfilteredJson: boolean;
 }
 
 const prettyJson = (json: string) => {
   return JSON.stringify(JSON.parse(json), null, 2);
 }
 
-export default class InputOutput extends Component<InputOutputProps> {
+export default class InputOutput extends Component<InputOutputProps, InputOutputState> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      hideUnfilteredJson: props.options["hideUnfilteredJsonByDefault"] 
+    };
+  }
+
   render() {
     const { inputJson, outputJson, options } = this.props;
+    const { hideUnfilteredJson } = this.state;
     const prettyInput = prettyJson(inputJson);
     const prettyOutput = prettyJson(outputJson);
-    const prettyOptions = JSON.parse(options);
+    const prettyOptions = options;
     return (
       <div class="row" id="editorDiv">
-        <div id="inputDiv" class="one-half column">
+        <div id="inputDiv" class={hideUnfilteredJson ? "hidden" : "one-half column"}>
           <BraceEditor
             name="json-editor-input"
             value={prettyInput}
@@ -30,14 +43,15 @@ export default class InputOutput extends Component<InputOutputProps> {
             <button id="copy-json-editor-input" onClick={() => Clipboard.copy(inputJson)}>Copy</button>
           </div>
         </div>
-        <div id="outputDiv" class="one-half column">
+        <div id="outputDiv" class={hideUnfilteredJson ? null : "one-half column"}>
           <BraceEditor
             name="json-editor-output"
             value={prettyOutput}
             options={prettyOptions}
           />
-          <div id="outputToolbar">
+          <div id="outputToolbar" class="button-group">
             <button id="copy-json-editor-output" onClick={() => Clipboard.copy(outputJson)}>Copy</button>
+            <button id="outputDiv-fullscreen-button" onClick={() => this.setState({hideUnfilteredJson: !hideUnfilteredJson})}>{!!hideUnfilteredJson && "Show Unfiltered JSON" || "Hide Unfiltered JSON"}</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR finishes completing the fixes described in https://github.com/zalando-incubator/bro-q/issues/224 and https://github.com/zalando-incubator/bro-q/issues/294 :

- The ACE editor window should not stretch below the bottom of the window to require scrolling the page to see long content (the input/output editors should be scrollable themselves)
- As #224 indicates, the liveURLQuery option does not work
- No button option to hide unfiltered input view

I'll let you all determine when to do the version bump.